### PR TITLE
refactor: rename sandbox to devvm across documentation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -19,21 +19,21 @@ O **DestaquesGovbr** é uma plataforma integrada de notícias e informações do
 ### Para Desenvolvedores Frontend (TypeScript)
 → Veja [onboarding/setup-frontend.md](onboarding/setup-frontend.md)
 
-### Ambiente de Desenvolvimento no GCP (Sandbox)
-→ Veja [onboarding/setup-sandbox.md](onboarding/setup-sandbox.md)
+### Ambiente de Desenvolvimento no GCP (Dev VM)
+→ Veja [onboarding/setup-devvm.md](onboarding/setup-devvm.md)
 
 ### Roteiro Completo de Onboarding
 → Veja [onboarding/roteiro-onboarding.md](onboarding/roteiro-onboarding.md)
 
 ---
 
-## Sandbox: Seu Ambiente no GCP
+## Dev VM: Seu Ambiente no GCP
 
 Cada desenvolvedor pode ter uma **VM dedicada no GCP** para desenvolvimento de código:
 
 ```mermaid
 flowchart LR
-    Dev[Seu Computador] -->|SSH via IAP| VM[Sandbox VM]
+    Dev[Seu Computador] -->|SSH via IAP| VM[Dev VM]
     VSCode[VSCode Remote] -->|SSH| VM
     VM -->|Git| GH[GitHub]
 ```
@@ -45,13 +45,13 @@ flowchart LR
 - 🛡️ **Seguro** - sem IP público, acesso apenas via IAP
 - 💰 **Econômico** - auto-shutdown às 19h
 
-**Para criar sua sandbox:**
+**Para criar sua Dev VM:**
 
 1. Clone o repo [destaquesgovbr-infra](https://github.com/destaquesgovbr/destaquesgovbr-infra)
 2. Adicione sua configuração em `terraform/terraform.tfvars`
 3. Abra um PR e aguarde o merge
 
-→ Guia completo: [infraestrutura/sandbox-vms.md](infraestrutura/sandbox-vms.md)
+→ Guia completo: [infraestrutura/devvm.md](infraestrutura/devvm.md)
 
 ## Arquitetura
 

--- a/docs/infraestrutura/devvm.md
+++ b/docs/infraestrutura/devvm.md
@@ -1,4 +1,4 @@
-# VMs Sandbox para Desenvolvimento
+# VMs de Desenvolvimento para Desenvolvimento
 
 > Ambientes de desenvolvimento isolados no GCP para a equipe.
 
@@ -6,7 +6,7 @@
 
 ## Visão Geral
 
-As sandboxes são VMs individuais no GCP criadas para cada desenvolvedor:
+As devvms são VMs individuais no GCP criadas para cada desenvolvedor:
 
 | Recurso | Especificação |
 |---------|---------------|
@@ -17,7 +17,7 @@ As sandboxes são VMs individuais no GCP criadas para cada desenvolvedor:
 | Auto-shutdown | 19:00 (Brasília) |
 | Região | southamerica-east1 (São Paulo) |
 
-### Por que usar sandbox?
+### Por que usar devvm?
 
 - **Ambiente padronizado**: Mesma configuração para toda equipe
 - **Persistência**: Projetos em `/mnt/data` sobrevivem reinicializações
@@ -39,10 +39,10 @@ flowchart TB
     subgraph GCP["GCP Project (inspire-7-finep)"]
         IAP[Identity-Aware Proxy]
 
-        subgraph VPC["VPC: sandbox-network"]
+        subgraph VPC["VPC: devvm-network"]
             subgraph Subnet["Subnet: 10.128.0.0/20"]
-                VM1[dev1-sandbox]
-                VM2[dev2-sandbox]
+                VM1[dev1-devvm]
+                VM2[dev2-devvm]
                 VMn[...]
             end
         end
@@ -61,10 +61,10 @@ flowchart TB
 
 ---
 
-## Como Solicitar uma Sandbox
+## Como Solicitar uma Dev VM
 
 !!! info "Gerenciado via Terraform"
-    As sandboxes são criadas automaticamente via CI/CD quando você abre um PR.
+    As devvms são criadas automaticamente via CI/CD quando você abre um PR.
 
 ### Passo 1: Clone o Repositório
 
@@ -78,7 +78,7 @@ cd destaquesgovbr-infra
 ```bash
 git checkout main
 git pull origin main
-git checkout -b feat/sandbox-seu-nome
+git checkout -b feat/devvm-seu-nome
 ```
 
 ### Passo 3: Adicione sua Configuração
@@ -86,8 +86,8 @@ git checkout -b feat/sandbox-seu-nome
 Edite `terraform/terraform.tfvars`:
 
 ```hcl
-sandboxes = {
-  # Sandboxes existentes...
+devvms = {
+  # Dev VMes existentes...
   nitai = {
     instance = {
       machine_type = "e2-standard-4"
@@ -109,8 +109,8 @@ sandboxes = {
 
 ```bash
 git add terraform/terraform.tfvars
-git commit -m "feat: add sandbox for seu-nome"
-git push origin feat/sandbox-seu-nome
+git commit -m "feat: add devvm for seu-nome"
+git push origin feat/devvm-seu-nome
 ```
 
 ### Passo 5: Abra um Pull Request
@@ -160,7 +160,7 @@ seu-nome = {
 ### Comando Básico
 
 ```bash
-gcloud compute ssh seu-nome-sandbox \
+gcloud compute ssh seu-nome-devvm \
   --zone=southamerica-east1-a \
   --tunnel-through-iap
 ```
@@ -169,7 +169,7 @@ gcloud compute ssh seu-nome-sandbox \
 
 ```bash
 # Ver se está rodando
-gcloud compute instances describe seu-nome-sandbox \
+gcloud compute instances describe seu-nome-devvm \
   --zone=southamerica-east1-a \
   --format="value(status)"
 ```
@@ -177,7 +177,7 @@ gcloud compute instances describe seu-nome-sandbox \
 ### Ligar VM (se desligada)
 
 ```bash
-gcloud compute instances start seu-nome-sandbox \
+gcloud compute instances start seu-nome-devvm \
   --zone=southamerica-east1-a
 ```
 
@@ -211,14 +211,14 @@ As VMs desligam automaticamente às **19:00** (horário de Brasília) para econo
 ### Ligar pela Manhã
 
 ```bash
-gcloud compute instances start seu-nome-sandbox \
+gcloud compute instances start seu-nome-devvm \
   --zone=southamerica-east1-a
 ```
 
 ### Desligar Manualmente
 
 ```bash
-gcloud compute instances stop seu-nome-sandbox \
+gcloud compute instances stop seu-nome-devvm \
   --zone=southamerica-east1-a
 ```
 
@@ -245,13 +245,13 @@ flowchart TD
 
 1. Verificar se está rodando:
    ```bash
-   gcloud compute instances describe seu-nome-sandbox \
+   gcloud compute instances describe seu-nome-devvm \
      --zone=southamerica-east1-a --format="value(status)"
    ```
 
 2. Se `TERMINATED`, ligar:
    ```bash
-   gcloud compute instances start seu-nome-sandbox \
+   gcloud compute instances start seu-nome-devvm \
      --zone=southamerica-east1-a
    ```
 
@@ -283,6 +283,6 @@ Edite `terraform.tfvars` e abra um PR para alterar `machine_type` ou `data_disk_
 
 ## Links Relacionados
 
-- [Setup VSCode Remote](../onboarding/setup-sandbox.md) - Configurar VSCode
+- [Setup VSCode Remote](../onboarding/setup-devvm.md) - Configurar VSCode
 - [Terraform Guide](./terraform-guide.md) - Como funciona o Terraform
 - [Arquitetura GCP](./arquitetura-gcp.md) - Visão geral

--- a/docs/onboarding/setup-devvm.md
+++ b/docs/onboarding/setup-devvm.md
@@ -1,6 +1,6 @@
-# Setup Sandbox (VSCode Remote)
+# Setup Dev VM (VSCode Remote)
 
-> Configurar VSCode para desenvolvimento remoto na sua VM sandbox.
+> Configurar VSCode para desenvolvimento remoto na sua Dev VM.
 
 ## Pré-requisitos
 
@@ -28,7 +28,7 @@ gcloud config get-value project  # inspire-7-finep
 Antes de configurar o VSCode, teste a conexão:
 
 ```bash
-gcloud compute ssh seu-nome-sandbox \
+gcloud compute ssh seu-nome-devvm \
   --zone=southamerica-east1-a \
   --tunnel-through-iap
 ```
@@ -36,7 +36,7 @@ gcloud compute ssh seu-nome-sandbox \
 !!! tip "VM desligada?"
     Se der erro, a VM pode estar desligada. Ligue com:
     ```bash
-    gcloud compute instances start seu-nome-sandbox \
+    gcloud compute instances start seu-nome-devvm \
       --zone=southamerica-east1-a
     ```
 
@@ -55,8 +55,8 @@ gcloud compute ssh seu-nome-sandbox \
     Adicione:
 
     ```ssh-config
-    Host sandbox
-        HostName seu-nome-sandbox
+    Host devvm
+        HostName seu-nome-devvm
         User seu-usuario
         ProxyCommand gcloud compute start-iap-tunnel %h %p --listen-on-stdin --project=inspire-7-finep --zone=southamerica-east1-a
         StrictHostKeyChecking no
@@ -64,7 +64,7 @@ gcloud compute ssh seu-nome-sandbox \
     ```
 
     !!! note "Substitua"
-        - `seu-nome-sandbox` → nome da sua VM
+        - `seu-nome-devvm` → nome da sua VM
         - `seu-usuario` → seu username Linux (geralmente parte do email antes do @)
 
 === "Windows"
@@ -72,8 +72,8 @@ gcloud compute ssh seu-nome-sandbox \
     Edite `C:\Users\SeuUsuario\.ssh\config`:
 
     ```ssh-config
-    Host sandbox
-        HostName seu-nome-sandbox
+    Host devvm
+        HostName seu-nome-devvm
         User seu-usuario
         ProxyCommand gcloud.cmd compute start-iap-tunnel %h %p --listen-on-stdin --project=inspire-7-finep --zone=southamerica-east1-a
         StrictHostKeyChecking no
@@ -86,7 +86,7 @@ gcloud compute ssh seu-nome-sandbox \
 ### Testar configuração
 
 ```bash
-ssh sandbox
+ssh devvm
 ```
 
 Deve conectar à VM.
@@ -101,7 +101,7 @@ Deve conectar à VM.
 
 3. Digite: **Remote-SSH: Connect to Host**
 
-4. Selecione **sandbox**
+4. Selecione **devvm**
 
 5. Aguarde a instalação do servidor VSCode (~1 min na primeira vez)
 
@@ -110,7 +110,7 @@ Deve conectar à VM.
 Após conectar, você verá no canto inferior esquerdo:
 
 ```
->< SSH: sandbox
+>< SSH: devvm
 ```
 
 ---
@@ -177,15 +177,15 @@ flowchart TD
 
 ```bash
 # Ligar VM
-gcloud compute instances start seu-nome-sandbox \
+gcloud compute instances start seu-nome-devvm \
   --zone=southamerica-east1-a
 
 # Verificar status
-gcloud compute instances describe seu-nome-sandbox \
+gcloud compute instances describe seu-nome-devvm \
   --zone=southamerica-east1-a --format="value(status)"
 
 # Desligar manualmente
-gcloud compute instances stop seu-nome-sandbox \
+gcloud compute instances stop seu-nome-devvm \
   --zone=southamerica-east1-a
 ```
 
@@ -199,11 +199,11 @@ A VM provavelmente está desligada:
 
 ```bash
 # Verificar
-gcloud compute instances describe seu-nome-sandbox \
+gcloud compute instances describe seu-nome-devvm \
   --zone=southamerica-east1-a --format="value(status)"
 
 # Ligar
-gcloud compute instances start seu-nome-sandbox \
+gcloud compute instances start seu-nome-devvm \
   --zone=southamerica-east1-a
 
 # Aguardar ~30s e reconectar
@@ -216,14 +216,14 @@ gcloud compute instances start seu-nome-sandbox \
 gcloud auth login
 
 # Tentar novamente
-ssh sandbox
+ssh devvm
 ```
 
 ### VSCode trava ao conectar
 
 ```bash
 # Conectar via terminal
-gcloud compute ssh seu-nome-sandbox \
+gcloud compute ssh seu-nome-devvm \
   --zone=southamerica-east1-a --tunnel-through-iap
 
 # Remover servidor VSCode corrompido
@@ -245,7 +245,7 @@ ProxyCommand "C:\Users\User\AppData\Local\Google\Cloud SDK\google-cloud-sdk\bin\
 Adicione keep-alive ao `~/.ssh/config`:
 
 ```ssh-config
-Host sandbox
+Host devvm
     # ... outras configs ...
     ServerAliveInterval 60
     ServerAliveCountMax 3
@@ -268,7 +268,7 @@ Se o ProxyCommand não funcionar no Windows:
 5. Configure VSCode para `localhost:PORTA`:
 
 ```ssh-config
-Host sandbox-tunnel
+Host devvm-tunnel
     HostName localhost
     Port 12345
     User seu-usuario
@@ -291,6 +291,6 @@ Agora que seu VSCode está configurado:
 
 ## Links Relacionados
 
-- [VMs Sandbox](../infraestrutura/sandbox-vms.md) - Criar e gerenciar sandboxes
+- [VMs de Desenvolvimento](../infraestrutura/devvm.md) - Criar e gerenciar Dev VMs
 - [Setup Backend](./setup-backend.md) - Configurar Python
 - [Setup Frontend](./setup-frontend.md) - Configurar Next.js

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,13 +62,13 @@ nav:
   - Infraestrutura:
     - Arquitetura GCP: infraestrutura/arquitetura-gcp.md
     - Terraform: infraestrutura/terraform-guide.md
-    - VMs Sandbox: infraestrutura/sandbox-vms.md
+    - VMs de Desenvolvimento: infraestrutura/devvm.md
     - Secrets & IAM: infraestrutura/secrets-iam.md
   - Onboarding:
     - Roteiro: onboarding/roteiro-onboarding.md
     - Setup Backend: onboarding/setup-backend.md
     - Setup Frontend: onboarding/setup-frontend.md
-    - Setup Sandbox: onboarding/setup-sandbox.md
+    - Setup Dev VM: onboarding/setup-devvm.md
     - Primeiro PR: onboarding/primeiro-pr.md
     - Troubleshooting: onboarding/troubleshooting.md
   - Sobre:


### PR DESCRIPTION
## Summary
- Rename `infraestrutura/sandbox-vms.md` → `infraestrutura/devvm.md`
- Rename `onboarding/setup-sandbox.md` → `onboarding/setup-devvm.md`
- Update mkdocs.yml navigation
- Update index.md links and terminology
- Replace all "sandbox" references with "devvm"
- Use "VMs de Desenvolvimento" or "Dev VM" in documentation

## Related PRs
- destaquesgovbr-infra #11 (terraform changes)
- reusable-terraform v1.2.0 (module refactor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)