### PR TITLE
docs: fachada GraphQL na arquitetura, ADR-002 e módulo

### DIFF
--- a/docs/arquitetura/adrs/adr-002-fachada-graphql.md
+++ b/docs/arquitetura/adrs/adr-002-fachada-graphql.md
@@ -1,0 +1,93 @@
+# ADR-002: Fachada GraphQL única para acesso a dados
+
+- **Status**: Aceita
+- **Data**: 2026-06-04
+- **Autor**: Nitai Bezerra
+
+## Contexto
+
+Até 2026, cada consumidor da plataforma falava **direto** com os backends de
+dados:
+
+- O **portal** lia/escrevia Firestore (clippings, marketplace, push, usuários) via
+  Firebase Admin SDK, consultava PostgreSQL para temas/órgãos e o Typesense para
+  busca — tudo em rotas REST internas (`/api/clipping`, `/api/clippings`,
+  `/api/push`, `/api/widgets`) e Server Components com acesso direto.
+- Os **workers de dados** (feature-worker, typesense-sync-worker, bronze-writer)
+  liam o PostgreSQL `govbrnews` diretamente via `DATABASE_URL`/asyncpg.
+
+### Problemas identificados
+
+1. **Acoplamento ao formato dos backends.** Cada consumidor conhecia o schema do
+   Firestore (camelCase, locais de coleção), o SQL do Postgres e o índice do
+   Typesense. Mudar qualquer backend vazava para vários repos.
+2. **Lógica e autenticação duplicadas.** Regras de autoria, permissões e
+   validação de JWT ficavam reimplementadas em cada rota REST do portal.
+3. **Contrato implícito e não-tipado.** Sem um schema único, divergências entre
+   o que o cliente esperava e o que o backend entregava só apareciam em runtime
+   (e, como se viu na R1, às vezes só no browser).
+4. **Difícil de evoluir.** Adicionar um campo significava tocar portal + rotas +
+   acesso a dados, sem um ponto único de versionamento.
+
+## Decisão
+
+Introduzir um serviço **`graphql-api`** (Strawberry GraphQL + FastAPI, Cloud Run)
+como **fachada de dados única**. Todos os consumidores passam a falar GraphQL com
+esse serviço, que é o único a conhecer Firestore/PostgreSQL/Typesense.
+
+### Princípios
+
+- **Schema tipado e code-first**, derivado do código Python; o SDL é a referência
+  versionada (gerado a cada build).
+- **Auth centralizada** em duas camadas: JWT de usuário (Keycloak) e OIDC de
+  service account (workers). Permissões declarativas por campo.
+- **Subscriptions-first** para clippings (relação usuário↔clipping via
+  `subscriptions` com `role`), suportando o marketplace sem duplicação.
+- **Rollout por feature flag** (GrowthBook `graphql.*`), com fallback REST mantido
+  durante a transição e removido no cleanup pós-estabilização.
+- **Streaming via SSE** (`/graphql/stream`) para o agente de IA, com passthrough
+  OIDC ao clipping worker.
+
+### Escopo da R1 (entregue)
+
+- Portal migrado (atrás de flags) para clippings, marketplace, push, widgets,
+  busca e agente.
+- Superfície **interna** para os workers já exposta no schema (`newsById`,
+  `newsForTypesense`, `newsBatchForBigquery`, `upsertFeatures`, …) — a migração
+  dos workers em si é um follow-up.
+
+## Alternativas consideradas
+
+- **Manter REST por endpoint.** Rejeitada: perpetua o contrato implícito e a
+  duplicação de auth; sem introspecção nem tipos.
+- **Manter acesso direto aos backends.** Rejeitada: é exatamente o acoplamento que
+  motivou a mudança.
+- **gRPC.** Descartada para o portal (browser/Next.js); GraphQL casa melhor com o
+  cliente web e com a necessidade de seleção de campos e subscriptions.
+
+## Consequências
+
+### Positivas
+
+- Consumidores desacoplados do formato dos backends; um ponto único de evolução.
+- Autenticação e regras de negócio centralizadas e testáveis.
+- Contrato tipado e introspectável; a referência de schema é gerada do código.
+
+### Negativas / riscos
+
+- **Risco de drift cliente↔schema.** Materializou-se na R1 (operações do portal
+  escritas contra um schema planejado, não o implementado). Mitigação: o gate de
+  validação passou a ser **E2E no browser** (Playwright contra portal+graphql-api),
+  não `curl` headless — porque o `curl` mascara CSP e o código TypeScript do
+  cliente. Catálogo de bugs: `graphql-api/_plan/R1-DRIFT-CATALOG.md`.
+- **CSP do portal precisa liberar a origin do serviço** (`connect-src`) — foi a
+  causa-raiz nº 1 da R1.
+- **Camada extra** entre cliente e dados: uma latência adicional e mais um serviço
+  para operar (mitigado por DataLoaders e cache por request).
+
+## Status de adoção
+
+- **Portal:** migrado em staging (R1), atrás de flags; produção segue o RUNBOOK-R1.
+- **Workers:** ainda acessam o PostgreSQL diretamente; migração para a fachada é o
+  próximo passo de desacoplamento.
+- Referência do serviço: [módulo GraphQL API](../../modulos/graphql-api.md).

--- a/docs/arquitetura/adrs/index.md
+++ b/docs/arquitetura/adrs/index.md
@@ -7,3 +7,4 @@ Cada ADR documenta o contexto, a decisão tomada, as alternativas consideradas e
 | ADR | Título | Status | Data |
 |-----|--------|--------|------|
 | [ADR-001](adr-001-arquitetura-dados-medallion.md) | Arquitetura de Dados Medallion com Feature Store JSONB | Proposta | 2026-03-01 |
+| [ADR-002](adr-002-fachada-graphql.md) | Fachada GraphQL única para acesso a dados | Aceita | 2026-06-04 |

--- a/docs/arquitetura/visao-geral.md
+++ b/docs/arquitetura/visao-geral.md
@@ -2,7 +2,7 @@
 
 ## Resumo
 
-O DestaquesGovbr é uma plataforma de agregação e enriquecimento de notícias governamentais composta por 7 camadas principais, com **arquitetura event-driven** e **pipeline Medallion**:
+O DestaquesGovbr é uma plataforma de agregação e enriquecimento de notícias governamentais composta por 8 camadas principais, com **arquitetura event-driven** e **pipeline Medallion**:
 
 1. **Coleta** - Raspagem automatizada de ~160 sites gov.br via Scraper API
 2. **Armazenamento Medallion** - Bronze (GCS Parquet) → Silver (PostgreSQL) → Gold (BigQuery + Feature Store)
@@ -11,6 +11,16 @@ O DestaquesGovbr é uma plataforma de agregação e enriquecimento de notícias 
 5. **Indexação** - Typesense para busca full-text e vetorial (atualizado via workers Pub/Sub)
 6. **Distribuição** - HuggingFace para dados abertos + Federação ActivityPub (Mastodon/Misskey)
 7. **Apresentação** - Portal Next.js, Streamlit App e Bots (Telegram)
+8. **Fachada de Dados** - GraphQL API unificada entre consumidores e backends
+
+!!! info "Fachada GraphQL (migração R1, 2026)"
+    Os consumidores (portal e, progressivamente, os workers) deixaram de acessar
+    Firestore/PostgreSQL/Typesense **diretamente** e passaram a usar uma fachada
+    GraphQL única — o serviço [`graphql-api`](../modulos/graphql-api.md). Isso
+    desacopla os consumidores do formato dos backends e centraliza a
+    autenticação. Ver [ADR-002](adrs/adr-002-fachada-graphql.md). O pipeline de
+    **ingestão** (camadas 1–6) segue acessando o PostgreSQL diretamente; migrar
+    os workers para a fachada é um passo de desacoplamento em andamento.
 
 **Mudança Arquitetural (Fev-Mar 2026)**: Pipeline migrado de **batch** (DAGs cron) para **event-driven** (Pub/Sub), reduzindo latência de **~45 min para ~15 segundos**.
 
@@ -289,11 +299,35 @@ Configurado para:
 
 | App | Tecnologia | URL | Descrição |
 |-----|------------|-----|-----------|
-| **Portal** | Next.js 15 + Typesense | [portal-klvx64dufq-rj.a.run.app](https://portal-klvx64dufq-rj.a.run.app/) | Interface web principal com busca, clippings, widgets |
+| **Portal** | Next.js 15 (busca via Typesense; clippings/marketplace/push/widgets via GraphQL) | [portal-klvx64dufq-rj.a.run.app](https://portal-klvx64dufq-rj.a.run.app/) | Interface web principal com busca, clippings, widgets |
 | **Streamlit** | Python + Altair | [HuggingFace Spaces](https://huggingface.co/spaces/nitaibezerra/govbrnews) | Análises exploratórias sobre o dataset |
 | **Telegram Bot** | Python + Aiogram | - | Bot para scraping sob demanda e alertas |
 
 → Detalhes do portal em [../modulos/portal.md](../modulos/portal.md)
+
+### 8. Fachada de Dados (`graphql-api`)
+
+Camada introduzida na migração R1 (2026). Um serviço Cloud Run
+([Strawberry GraphQL + FastAPI](../modulos/graphql-api.md)) que expõe um schema
+tipado único e intermedeia o acesso aos backends, em vez de cada consumidor
+falar direto com Firestore/PostgreSQL/Typesense.
+
+```mermaid
+flowchart LR
+    portal[Portal Next.js] -->|HTTP + JWT| api
+    workers[Workers de dados<br/>migração em andamento] -.->|HTTP + OIDC| api
+    embed[Widgets embarcáveis] -->|HTTP público| api
+    api[graphql-api<br/>Strawberry + FastAPI] --> fs[(Firestore)]
+    api --> pg[(PostgreSQL)]
+    api --> ts[(Typesense)]
+```
+
+- **Portal**: clippings, marketplace, push, widgets e busca via GraphQL (atrás de
+  feature flags `graphql.*`); o agente de IA transmite por SSE (`/graphql/stream`).
+- **Workers**: têm uma superfície interna (`newsForTypesense`, `upsertFeatures`, …)
+  pronta para migrarem do acesso direto ao Postgres.
+- Detalhes, schema e exemplos: [módulo GraphQL API](../modulos/graphql-api.md) e
+  a [documentação profunda do serviço](https://destaquesgovbr.github.io/graphql-api/).
 
 ## Event Mesh (Cloud Pub/Sub)
 

--- a/docs/infraestrutura/arquitetura-gcp.md
+++ b/docs/infraestrutura/arquitetura-gcp.md
@@ -133,6 +133,25 @@ flowchart TB
 - VPC Connector para acesso ao PostgreSQL
 - GPU opcional para maior throughput
 
+### 4b. Cloud Run (GraphQL API)
+
+| Propriedade | Valor |
+|-------------|-------|
+| Serviço | `destaquesgovbr-graphql-api` |
+| Região | `southamerica-east1` |
+| Stack | Strawberry GraphQL + FastAPI (Python 3.12) |
+| Min instances | 0 |
+
+**Características:**
+
+- Fachada de dados única (Firestore + PostgreSQL + Typesense) — ver
+  [ADR-002](../arquitetura/adrs/adr-002-fachada-graphql.md) e o
+  [módulo GraphQL API](../modulos/graphql-api.md).
+- Auth: JWT do Keycloak (usuários) + OIDC do Google (service accounts/workers).
+- Env vars geridas pelo Terraform; SSE em `/graphql/stream` para o agente de IA.
+- IAM: a SA do portal e a SA do graphql-api têm `roles/run.invoker` onde
+  necessário (ex.: graphql-api → clipping worker para o passthrough do agente).
+
 ### 5. Compute Engine (Typesense)
 
 | Propriedade | Valor |
@@ -161,6 +180,7 @@ flowchart TB
 - `portal` - Imagem do portal Next.js
 - `data-platform` - Imagem do data platform
 - `embeddings-api` - Imagem da API de embeddings
+- `destaquesgovbr-graphql-api` - Imagem da fachada GraphQL
 
 ### 7. Secret Manager
 

--- a/docs/modulos/graphql-api.md
+++ b/docs/modulos/graphql-api.md
@@ -1,0 +1,61 @@
+# GraphQL API
+
+API GraphQL **unificada** — a fachada de dados única entre os consumidores da
+plataforma (portal, workers de dados) e os backends de persistência.
+
+!!! info "Repositório"
+    **GitHub**: [destaquesgovbr/graphql-api](https://github.com/destaquesgovbr/graphql-api)
+
+    **URL (staging)**: [destaquesgovbr-graphql-api-klvx64dufq-rj.a.run.app](https://destaquesgovbr-graphql-api-klvx64dufq-rj.a.run.app/graphql)
+
+## Visão Geral
+
+Antes, o portal e os workers falavam **direto** com cada backend (Firestore via
+Firebase Admin, PostgreSQL via SQL, Typesense via SDK). O `graphql-api` introduz
+uma fachada tipada única: um schema, um ponto de evolução, auth centralizada.
+
+```mermaid
+flowchart LR
+    portal[Portal Next.js] -->|HTTP + JWT| api
+    workers[Workers de dados] -->|HTTP + OIDC| api
+    embed[Widgets embarcáveis] -->|HTTP público| api
+    api[graphql-api<br/>Strawberry + FastAPI] --> fs[(Firestore)]
+    api --> pg[(PostgreSQL<br/>govbrnews)]
+    api --> ts[(Typesense)]
+```
+
+## Papel na plataforma
+
+- **Portal** consome clippings, marketplace, push, widgets e busca via GraphQL
+  (atrás de feature flags `graphql.*`, durante a migração R1).
+- **Workers de dados** (feature-worker, typesense-sync-worker, bronze-writer) têm
+  uma superfície **interna** (`newsForTypesense`, `upsertFeatures`, …) disponível
+  para migrarem do acesso direto ao Postgres — desacoplando ainda mais a
+  plataforma.
+- **Agente de IA** (geração de recortes) transmite em tempo real via SSE
+  (`/graphql/stream`), com passthrough para o clipping worker.
+
+## Stack
+
+| Camada | Tecnologia |
+|--------|-----------|
+| Schema | Strawberry GraphQL (code-first, Python 3.12) |
+| HTTP | FastAPI + Uvicorn |
+| Subscriptions | SSE via `/graphql/stream` |
+| Auth | JWT (Keycloak, usuários) + OIDC (service accounts) |
+| Datasources | asyncpg, firebase-admin, typesense-python |
+| Deploy | Cloud Run, env vars via Terraform |
+
+!!! tip "Playground interativo (GraphiQL)"
+    A API serve o **GraphiQL** nativo em `GET /graphql` — explore o schema e rode
+    queries no browser:
+    [playground (staging)](https://destaquesgovbr-graphql-api-klvx64dufq-rj.a.run.app/graphql).
+
+!!! tip "Documentação profunda"
+    A referência completa — arquitetura, datasources, auth, subscriptions e o
+    **SDL gerado do código** — vive co-localizada no repo do serviço:
+
+    **→ [Documentação profunda do graphql-api](https://destaquesgovbr.github.io/graphql-api/)**
+
+    (gerada por MkDocs a partir de `graphql-api/docs/`; o SDL é exportado do
+    schema Strawberry a cada build, sempre em sincronia com o código).

--- a/docs/modulos/portal.md
+++ b/docs/modulos/portal.md
@@ -42,6 +42,30 @@ flowchart LR
 
 ---
 
+## Acesso a dados via GraphQL (migração R1)
+
+Além da busca de notícias (Typesense), o portal oferece funcionalidades dinâmicas
+— **clippings**, **marketplace**, **notificações push**, **widgets** e o **agente
+de IA**. Na migração R1 (2026) esse acesso a dados deixou de usar rotas REST
+internas + Firebase Admin direto e passou a consumir a fachada
+[`graphql-api`](graphql-api.md):
+
+- Cliente **urql** com *auth-exchange* que envia o `Authorization: Bearer <JWT>`
+  (token do Keycloak exposto na sessão NextAuth).
+- Roteamento por **feature flag** (GrowthBook `graphql.*`): cada feature alterna
+  entre a implementação GraphQL e o fallback REST legado, removível no cleanup.
+- O **CSP** do portal precisa incluir a origin do graphql-api em `connect-src`
+  (senão o browser bloqueia o fetch) — foi a causa-raiz nº 1 da migração.
+- O **agente** transmite via SSE em `/graphql/stream` (não `/graphql`).
+
+!!! warning "Gate de validação: E2E no browser, nunca só curl"
+    A validação da migração é feita com **Playwright** dirigindo o browser real
+    contra portal + graphql-api (`portal/e2e/graphql/`). `curl` headless mascara
+    o CSP e o código TypeScript do cliente — foi assim que um drift de schema
+    passou despercebido. Ver [ADR-002](../arquitetura/adrs/adr-002-fachada-graphql.md).
+
+---
+
 ## Estrutura do Repositório
 
 ```

--- a/docs/onboarding/setup-backend.md
+++ b/docs/onboarding/setup-backend.md
@@ -378,6 +378,25 @@ poetry install --sync
 
 ---
 
+## GraphQL API — fachada de dados
+
+O acesso a dados dos consumidores (portal e, em migração, os workers) passa pela
+fachada [`graphql-api`](../modulos/graphql-api.md) (Strawberry + FastAPI). Se for
+trabalhar nela ou no portal:
+
+```bash
+git clone https://github.com/destaquesgovbr/graphql-api.git
+cd graphql-api
+make bootstrap-env   # puxa secrets do GCP Secret Manager para .env.local
+make dev             # uvicorn em :8000 (Firestore/Postgres/Typesense reais)
+```
+
+- Setup dev local completo (portal :3000 + graphql-api :8000 + Keycloak Cloud Run)
+  está no `CLAUDE.md` de cada repo.
+- **Gate de validação:** Playwright no browser (`portal/e2e/graphql/`), nunca só
+  `curl` — `curl` mascara CSP e o código do cliente. Ver
+  [ADR-002](../arquitetura/adrs/adr-002-fachada-graphql.md).
+
 ## Próximos Passos
 
 1. Leia o código do `webscraper.py` para entender o scraping

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,10 +57,12 @@ nav:
     - ADRs:
       - Índice: arquitetura/adrs/index.md
       - "ADR-001: Arquitetura de Dados Medallion": arquitetura/adrs/adr-001-arquitetura-dados-medallion.md
+      - "ADR-002: Fachada GraphQL": arquitetura/adrs/adr-002-fachada-graphql.md
   - Módulos:
     - Data Platform: modulos/data-platform.md
     - Scraper: modulos/scraper.md
     - Portal: modulos/portal.md
+    - GraphQL API: modulos/graphql-api.md
     - Cogfy/LLM: modulos/cogfy-integracao.md
     - Árvore Temática: modulos/arvore-tematica.md
     - Órgãos: modulos/agencies.md


### PR DESCRIPTION
## O que

Reflete a migração GraphQL (R1) na documentação central, considerando as refatorações feitas.

- **Arquitetura › Visão Geral**: introduz a **8ª camada — fachada de dados** (graphql-api) entre consumidores e backends, com diagrama; nota de que a ingestão segue direta (migração dos workers em andamento).
- **ADR-002 — Fachada GraphQL única**: contexto, decisão, alternativas e consequências (incl. a lição *gate E2E no browser, nunca curl*). Registrado no índice de ADRs e no nav.
- **Módulos › GraphQL API**: nova página de entrada, com link para a documentação profunda do serviço e para o **playground GraphiQL**.
- **Módulos › Portal**: seção de consumo via GraphQL (urql + flags + CSP + SSE) e o gate de validação.
- **Infra › Arquitetura GCP**: serviço `destaquesgovbr-graphql-api` (Cloud Run + Artifact Registry).
- **Onboarding › Backend**: setup local do graphql-api + gate de validação.

## Fora deste PR
- O **blog post** sobre a refatoração foi deixado de fora (a publicar separadamente).

## Validação
- `mkdocs build` limpo (sem links/nav quebrados; mermaid renderiza).