### PR TITLE
fix: link de tela cheia dos slides (renderização)

### DIFF
--- a/docs/apresentacoes/mlflow-no-dgb/index.md
+++ b/docs/apresentacoes/mlflow-no-dgb/index.md
@@ -15,7 +15,7 @@ no GCS) e como começar a usar hoje. São **20 slides**, 16:9.
           style="position:absolute;inset:0;width:100%;height:100%;border:0;"></iframe>
 </div>
 
-[:material-fullscreen: Abrir os slides em tela cheia →](deck.html){target=_blank}
+<p><a href="deck.html" target="_blank" rel="noopener">⛶ Abrir os slides em tela cheia →</a></p>
 
 ---
 


### PR DESCRIPTION
O link "Abrir os slides em tela cheia" aparecia como texto cru (`:material-fullscreen: ... {target=_blank}`) porque o mkdocs.yml não habilita `pymdownx.emoji` nem `attr_list`. Fix: âncora HTML `<a href target=_blank rel=noopener>`, sem depender de extensão. Verificado com mkdocs build.